### PR TITLE
Allow the use of native modules on MinGW.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -129,6 +129,8 @@ project "qjsc"
 	files {
 		"qjsc.c"
 	}
+	filter { "action:gmake*", "toolset:gcc" }
+		links { "dl", "pthread" }
 
 -----------------------------------------------------------------------------------------------------------------------
 
@@ -144,6 +146,8 @@ project "qjs"
 		"qjscalc.js",
 		"qjscalc.c"
 	}
+	filter { "action:gmake*", "toolset:gcc" }
+		links { "dl", "pthread" }
 
 -- Compile repl.js and save bytecode into repl.c
 prebuildcommands { "\"%{cfg.buildtarget.directory}/qjsc.exe\" -c -o \"../../repl.c\" -m \"../../repl.js\"" }

--- a/qjsc.c
+++ b/qjsc.c
@@ -32,7 +32,11 @@
 #include <sys/wait.h>
   #include <unistd.h>
 #else
+  #if !defined(__MINGW32__)
   #include "win/getopt.h"
+  #else
+    #include <unistd.h>
+  #endif
 #endif
 
 #include "cutils.h"

--- a/qjsc.c
+++ b/qjsc.c
@@ -248,7 +248,7 @@ JSModuleDef *jsc_module_loader(JSContext *ctx,
         namelist_add(&init_module_list, e->name, e->short_name, 0);
         /* create a dummy module */
         m = JS_NewCModule(ctx, module_name, js_module_dummy_init);
-    } else if (has_suffix(module_name, ".so")) {
+    } else if (has_suffix(module_name, NATIVE_MODULE_SUFFIX)) {
         fprintf(stderr, "Warning: binary module '%s' will be dynamically loaded\n", module_name);
         /* create a dummy module */
         m = JS_NewCModule(ctx, module_name, js_module_dummy_init);
@@ -767,3 +767,5 @@ int main(int argc, char **argv)
     namelist_free(&init_module_list);
     return 0;
 }
+
+#undef NATIVE_MODULE_SUFFIX

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -35,6 +35,9 @@
 #include <limits.h>
 #include <sys/stat.h>
 #if defined(_WIN32)
+  #if defined(__MINGW32__)
+    #include <dlfcn.h>
+  #endif
   #include <windows.h>
   #include <conio.h>
   #include <io.h>
@@ -463,7 +466,7 @@ typedef JSModuleDef *(JSInitModuleFunc)(JSContext *ctx,
                                         const char *module_name);
 
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 static JSModuleDef *js_module_loader_so(JSContext *ctx,
                                         const char *module_name)
 {

--- a/quickjs-libc.c
+++ b/quickjs-libc.c
@@ -582,7 +582,7 @@ JSModuleDef *js_module_loader(JSContext *ctx,
 {
     JSModuleDef *m;
 
-    if (has_suffix(module_name, ".so")) {
+    if (has_suffix(module_name, NATIVE_MODULE_SUFFIX)) {
         m = js_module_loader_so(ctx, module_name);
     } else {
         size_t buf_len;

--- a/quickjs.c
+++ b/quickjs.c
@@ -31,7 +31,9 @@
 #include <time.h>
 #include <fenv.h>
 #include <math.h>
-#if defined(__APPLE__)
+#if defined(_WIN32)
+#include <timezoneapi.h>
+#elif defined(__APPLE__)
 #include <malloc/malloc.h>
 #include <sys/time.h>
 #elif defined(__linux__)

--- a/quickjs.h
+++ b/quickjs.h
@@ -30,6 +30,14 @@
 #include <math.h>
 #include "quickjs-version.h"
 
+#if defined(_WIN32)
+  #define NATIVE_MODULE_SUFFIX ".dll"
+#elif defined(__APPLE__)
+  #define NATIVE_NATIVE_MODULE_SUFFIX ".dylib"
+#else
+  #define NATIVE_MODULE_SUFFIX ".so"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This should allow the use of native modules on MinGW. This replaces the instances in the code where it looks for specifically ".so" as a suffix and replaces it with a new define "NATIVE_MODULE_SUFFIX" that expands to the appropriate one depending on the platform. This also fixes compilation on MinGW environments.